### PR TITLE
Modis lidar bug fix

### DIFF
--- a/MISR_simulator/MISR_simulator.f
+++ b/MISR_simulator/MISR_simulator.f
@@ -283,60 +283,63 @@
 
         !     
         !   Modify MISR CTH for satellite spatial / pattern matcher effects
-    !
-    !   Code in this region added by roj 5/2006 to account
-    !   for spatial effect of the MISR pattern matcher.
-    !   Basically, if a column is found between two neighbors
-    !   at the same CTH, and that column has no hieght or
-    !   a lower CTH, THEN misr will tend to but place the
-    !   odd column at the same height as it neighbors.
-    !
-    !   This setup assumes the columns represent a about a 1 to 4 km scale
-    !   it will need to be modified significantly, otherwise
-        if(ncol.eq.1) then
-    
-       ! adjust based on neightboring points ... i.e. only 2D grid was input
-           do j=2,npoints-1
-            
-            if(box_MISR_ztop(j-1,1).gt.0 .and. 
-     &             box_MISR_ztop(j+1,1).gt.0       ) then
+    	!
+    	!   Code in this region added by roj 5/2006 to account
+    	!   for spatial effect of the MISR pattern matcher.
+    	!   Basically, if a column is found between two neighbors
+    	!   at the same CTH, and that column has no hieght or
+    	!   a lower CTH, THEN misr will tend to but place the
+    	!   odd column at the same height as it neighbors.
+    	!
+    	!   This setup assumes the columns represent a about a 1 to 4 km scale
+    	!   it will need to be modified significantly, otherwise
 
-                if( abs( box_MISR_ztop(j-1,1) -  
-     &                   box_MISR_ztop(j+1,1) ) .lt. 500 
-     &              .and.
-     &                   box_MISR_ztop(j,1) .lt. 
-     &                   box_MISR_ztop(j+1,1)     ) then
-            
-                    box_MISR_ztop(j,1) =
-     &                      box_MISR_ztop(j+1,1)    
-                endif
-
-            endif
-         enddo
-        else
-         
+    ! Commented out.  Should only be used with subcolumns are not randomly ordered.  Roj 4/2018
+    !
+    !    if(ncol.eq.1) then
+    !   
+       	 ! adjust based on neightboring points ... i.e. only 2D grid was input
+    !       do j=2,npoints-1
+    !        
+    !        if(box_MISR_ztop(j-1,1).gt.0 .and. 
+    ! &             box_MISR_ztop(j+1,1).gt.0       ) then
+    !
+    !            if( abs( box_MISR_ztop(j-1,1) -  
+    ! &                   box_MISR_ztop(j+1,1) ) .lt. 500 
+    ! &              .and.
+    ! &                   box_MISR_ztop(j,1) .lt. 
+    ! &                   box_MISR_ztop(j+1,1)     ) then
+    !            
+    !                box_MISR_ztop(j,1) =
+    ! &                      box_MISR_ztop(j+1,1)    
+    !            endif
+    !
+    !        endif
+    !     enddo
+    !    else
+    !     
          ! adjust based on neighboring subcolumns ....
-         do ibox=2,ncol-1
-            
-            if(box_MISR_ztop(1,ibox-1).gt.0 .and. 
-     &             box_MISR_ztop(1,ibox+1).gt.0        ) then
+    !     do ibox=2,ncol-1
+    !        
+    !        if(box_MISR_ztop(1,ibox-1).gt.0 .and. 
+    ! &             box_MISR_ztop(1,ibox+1).gt.0        ) then
+    !
+    !            if( abs( box_MISR_ztop(1,ibox-1) -  
+    ! &                   box_MISR_ztop(1,ibox+1) ) .lt. 500 
+    ! &              .and.
+    ! &                   box_MISR_ztop(1,ibox) .lt. 
+    ! &                   box_MISR_ztop(1,ibox+1)     ) then
+    !        
+    !                box_MISR_ztop(1,ibox) =
+    ! &                      box_MISR_ztop(1,ibox+1)    
+    !            endif
+    !
+    !        endif
+    !     enddo
+    !  
+    !    endif
 
-                if( abs( box_MISR_ztop(1,ibox-1) -  
-     &                   box_MISR_ztop(1,ibox+1) ) .lt. 500 
-     &              .and.
-     &                   box_MISR_ztop(1,ibox) .lt. 
-     &                   box_MISR_ztop(1,ibox+1)     ) then
-            
-                    box_MISR_ztop(1,ibox) =
-     &                      box_MISR_ztop(1,ibox+1)    
-                endif
-
-            endif
-         enddo
-      
-        endif
-
-        !     
+    !     
     !     DETERMINE CLOUD TYPE FREQUENCIES
     !
     !     Now that ztop and tau have been determined, 

--- a/MODIS_simulator/modis_simulator.F90
+++ b/MODIS_simulator/modis_simulator.F90
@@ -501,34 +501,47 @@ contains
     ! ########################################################################################
     ! Compute mean optical thickness.
     ! ########################################################################################
-    Optical_Thickness_Total_Mean(1:nPoints) = sum(optical_thickness, mask = cloudMask,      dim = 2) / &
-                                              Cloud_Fraction_Total_Mean(1:nPoints) 
-    Optical_Thickness_Water_Mean(1:nPoints) = sum(optical_thickness, mask = waterCloudMask, dim = 2) / &
-                                              Cloud_Fraction_Water_Mean(1:nPoints)
-    Optical_Thickness_Ice_Mean(1:nPoints)   = sum(optical_thickness, mask = iceCloudMask,   dim = 2) / &
-                                              Cloud_Fraction_Ice_Mean(1:nPoints)
-       
-    ! ########################################################################################
-    ! We take the absolute value of optical thickness here to satisfy compilers that complains 
-    ! when we evaluate the logarithm of a negative number, even though it's not included in 
-    ! the sum. 
-    ! ########################################################################################
-    Optical_Thickness_Total_MeanLog10(1:nPoints) = sum(log10(abs(optical_thickness)), mask = cloudMask, &
-         dim = 2) / Cloud_Fraction_Total_Mean(1:nPoints)
-    Optical_Thickness_Water_MeanLog10(1:nPoints) = sum(log10(abs(optical_thickness)), mask = waterCloudMask,&
-         dim = 2) / Cloud_Fraction_Water_Mean(1:nPoints)
-    Optical_Thickness_Ice_MeanLog10(1:nPoints) = sum(log10(abs(optical_thickness)), mask = iceCloudMask,&
-         dim = 2) / Cloud_Fraction_Ice_Mean(1:nPoints)
-    Cloud_Particle_Size_Water_Mean(1:nPoints) = sum(particle_size, mask = waterCloudMask, dim = 2) / &
-         Cloud_Fraction_Water_Mean(1:nPoints)
-    Cloud_Particle_Size_Ice_Mean(1:nPoints) = sum(particle_size, mask = iceCloudMask,   dim = 2) / &
-         Cloud_Fraction_Ice_Mean(1:nPoints)
-    Cloud_Top_Pressure_Total_Mean(1:nPoints) = sum(cloud_top_pressure, mask = cloudMask, dim = 2) / &
-         max(1, count(cloudMask, dim = 2))
-    Liquid_Water_Path_Mean(1:nPoints) = LWP_conversion*sum(particle_size*optical_thickness, &
-         mask=waterCloudMask,dim=2)/Cloud_Fraction_Water_Mean(1:nPoints)
-    Ice_Water_Path_Mean(1:nPoints) = LWP_conversion * ice_density*sum(particle_size*optical_thickness,&
-         mask=iceCloudMask,dim = 2) /Cloud_Fraction_Ice_Mean(1:nPoints)
+    where(Cloud_Fraction_Total_Mean(1:nPoints) > 0)
+       Optical_Thickness_Total_Mean(1:nPoints) = sum(optical_thickness, mask = cloudMask,      dim = 2) / &
+            Cloud_Fraction_Total_Mean(1:nPoints)
+       Optical_Thickness_Total_MeanLog10(1:nPoints) = sum(log10(abs(optical_thickness)), mask = cloudMask, &
+            dim = 2) / Cloud_Fraction_Total_Mean(1:nPoints)
+    elsewhere
+       Optical_Thickness_Total_Mean      = 0.
+       Optical_Thickness_Total_MeanLog10 = 0.
+    endwhere
+    where(Cloud_Fraction_Water_Mean(1:nPoints) > 0)
+       Optical_Thickness_Water_Mean(1:nPoints) = sum(optical_thickness, mask = waterCloudMask, dim = 2) / &
+            Cloud_Fraction_Water_Mean(1:nPoints)
+       Liquid_Water_Path_Mean(1:nPoints) = LWP_conversion*sum(particle_size*optical_thickness, &
+            mask=waterCloudMask,dim=2)/Cloud_Fraction_Water_Mean(1:nPoints)
+       Optical_Thickness_Water_MeanLog10(1:nPoints) = sum(log10(abs(optical_thickness)), mask = waterCloudMask,&
+            dim = 2) / Cloud_Fraction_Water_Mean(1:nPoints)
+       Cloud_Particle_Size_Water_Mean(1:nPoints) = sum(particle_size, mask = waterCloudMask, dim = 2) / &
+            Cloud_Fraction_Water_Mean(1:nPoints)
+    elsewhere
+       Optical_Thickness_Water_Mean      = 0.
+       Optical_Thickness_Water_MeanLog10 = 0.
+       Cloud_Particle_Size_Water_Mean    = 0.
+       Liquid_Water_Path_Mean            = 0.
+    endwhere
+    where(Cloud_Fraction_Ice_Mean(1:nPoints) > 0)
+       Optical_Thickness_Ice_Mean(1:nPoints)   = sum(optical_thickness, mask = iceCloudMask,   dim = 2) / &
+            Cloud_Fraction_Ice_Mean(1:nPoints)
+       Ice_Water_Path_Mean(1:nPoints) = LWP_conversion * ice_density*sum(particle_size*optical_thickness,&
+            mask=iceCloudMask,dim = 2) /Cloud_Fraction_Ice_Mean(1:nPoints) 
+       Optical_Thickness_Ice_MeanLog10(1:nPoints) = sum(log10(abs(optical_thickness)), mask = iceCloudMask,&
+            dim = 2) / Cloud_Fraction_Ice_Mean(1:nPoints)
+       Cloud_Particle_Size_Ice_Mean(1:nPoints) = sum(particle_size, mask = iceCloudMask,   dim = 2) / &
+            Cloud_Fraction_Ice_Mean(1:nPoints)    
+    elsewhere
+       Optical_Thickness_Ice_Mean        = 0.
+       Optical_Thickness_Ice_MeanLog10   = 0.
+       Cloud_Particle_Size_Ice_Mean      = 0.
+       Ice_Water_Path_Mean               = 0.
+    endwhere
+    Cloud_Top_Pressure_Total_Mean  = sum(cloud_top_pressure, mask = cloudMask, dim = 2) / &
+                                     max(1, count(cloudMask, dim = 2))
 
     ! ########################################################################################
     ! Normalize pixel counts to fraction.
@@ -560,10 +573,7 @@ contains
        Cloud_Particle_Size_Ice_Mean      = R_UNDEF
        Ice_Water_Path_Mean               = R_UNDEF
     endwhere
-    where (Cloud_Fraction_High_Mean == 0)  Cloud_Fraction_High_Mean = R_UNDEF
-    where (Cloud_Fraction_Mid_Mean == 0)   Cloud_Fraction_Mid_Mean = R_UNDEF
-    where (Cloud_Fraction_Low_Mean == 0)   Cloud_Fraction_Low_Mean = R_UNDEF
-
+    
     ! ########################################################################################
     ! Joint histogram  
     ! ########################################################################################


### PR DESCRIPTION
Recently some small issues were uncovered by modeling centers implementing COSP1.4.2. and I propose we include these changes on the COSP1 master branch.

*) In the LIDAR simulator there was a division-by-zero for scenes for really thick clouds. This does not impact any of the CALIPSO LIDAR diagnostics

*) In the MODIS simulator, some of the gridmean diagnostics were being set to zero for clear scenes, when they should have been set to undefined. This impacted the averaging being performed by the model, resulting in much large values than expected. In the offline tests, we see the following:
  lwpmodis:            69.28 % of values differ, relative range:  -5.19e-01 to  3.00e+00
  tautlogmodis:         9.15 % of values differ, relative range:  -8.96e-01 to  1.43e+00
  iwpmodis:            34.64 % of values differ, relative range:  -1.16e-01 to  4.26e-01
  tauimodis:            0.65 % of values differ, relative range:   1.03e-01 to  1.03e-01
  tauwmodis:            8.50 % of values differ, relative range:  -5.66e-01 to  3.10e+00
  tautmodis:            9.15 % of values differ, relative range:  -5.66e-01 to  3.10e+00
  reffclimodis:        34.64 % of values differ, relative range:  -2.24e-01 to  4.26e-01
  reffclwmodis:        69.28 % of values differ, relative range:  -1.85e-01 to  3.21e-01
  tauwlogmodis:         8.50 % of values differ, relative range:  -8.96e-01 to  1.43e+00
  clwmodis:             8.50 % of values differ, relative range:  -8.00e-01 to  6.67e-01
  cltmodis:             9.15 % of values differ, relative range:  -8.00e-01 to  1.76e-01
  cllmodis:             5.88 % of values differ, relative range:  -8.00e-01 to -2.50e-01
  climodis:             0.65 % of values differ, relative range:  -1.43e-01 to -1.43e-01
  clhmodis:             1.31 % of values differ, relative range:  -1.25e-01 to  2.14e-01
  pctmodis:             9.15 % of values differ, relative range:  -4.26e-01 to  1.05e-01
  tauilogmodis:         0.65 % of values differ, relative range:   6.50e+00 to  6.50e+00
  clmodis:              0.04 % of values differ, relative range:  -3.33e-01 to  6.00e-01

For both cases, diagnostics requested for CFMIP3/CMIP6 are not impacted.